### PR TITLE
refactor(nep21): link to the original PR

### DIFF
--- a/specs/Standards/Tokens/FungibleToken.md
+++ b/specs/Standards/Tokens/FungibleToken.md
@@ -1,4 +1,4 @@
-# Fungible Token
+# Fungible Token ([NEP-21](https://github.com/nearprotocol/NEPs/pull/21))
 
 Version `0.2.0`
 


### PR DESCRIPTION
We often call this the "NEP21" standard, but this document by itself never mentions this code name. Links directly to this document, rather than to the potentially-outdated pull request, will not reveal this shorthand.

I'm not sure it's worth linking to the original pull-request. On the one hand, it explains where the `21` comes from. On the other hand, the PR is potentially outdated. Is it worth linking to?