### PR TITLE
Emphasizing that the `approvals_after_next` can contain trailing sign…

### DIFF
--- a/specs/ChainSpec/LightClient.md
+++ b/specs/ChainSpec/LightClient.md
@@ -161,7 +161,9 @@ By construction by the time the `LightClientBlockView` is being validated, the b
 
 The sum of all the stakes of `next_bps` in the previous epoch is `total_stake` referred to in (5) above.
 
-The signatures in the `LightClientBlockView::approvals_after_next` are signatures on `approval_message`. The  `i`-th signature in `approvals_after_next`, if present, must validate against the `i`-th public key in `next_bps` from the previous epoch. `approvals_after_next` can contain fewer elements than `next_bps` in the previous epoch.
+The signatures in the `LightClientBlockView::approvals_after_next` are signatures on `approval_message`. The  `i`-th signature in `approvals_after_next`, if present, must validate against the `i`-th public key in `next_bps` from the previous epoch. `approvals_after_next` can contain fewer elements than `next_bps` in the previous epoch. 
+
+`approvals_after_next` can also contain more signatures than the length of `next_bps` in the previous epoch. This is due to the fact that, as per [consensus specification](./Consensus.md), the last blocks in each epoch contain signatures from both the block producers of the current epoch, and the next epoch. The trailing signatures can be safely ignored by the light client implementation.
 
 ## Proof Verification
 


### PR DESCRIPTION
…atures

As per https://github.com/nearprotocol/nearcore/issues/3307, the spec is
not very explicit about the fact that `approvals_after_next` can be
longer than previous epoch `next_bps`. The actual pseudocode in the spec
is actually correct, but the correctness is due to the specific behavior
of `zip` in python, and it is extremely easy to overlook that particular
behavior and implement the zipping with an expectation that the length
is at most that of `next_bps`.

I'm adding an emphasis in the relevant section that the lenght of
`approvals_аfter_next` can be both smaller and larger than that of
`next_bps`.